### PR TITLE
docs(data-sources): add SQL and GA4 source pages

### DIFF
--- a/.vitepress/config.ts
+++ b/.vitepress/config.ts
@@ -118,6 +118,8 @@ function v2DocsSidebar(lang: 'en' | 'ja'): DefaultTheme.SidebarItem[] {
       items: [
         { text: 'CSV / Parquet', link: `${prefix}/data-sources/csv` },
         { text: 'BigQuery', link: `${prefix}/data-sources/bigquery` },
+        { text: 'SQL', link: `${prefix}/data-sources/sql` },
+        { text: 'GA4', link: `${prefix}/data-sources/ga4` },
         { text: lang === 'ja' ? 'プラグイン' : 'Plugins', link: `${prefix}/data-sources/plugins` },
       ],
     },

--- a/docs/data-sources/ga4.md
+++ b/docs/data-sources/ga4.md
@@ -1,0 +1,131 @@
+---
+title: GA4 Source
+---
+
+# GA4 Source
+
+The `ga4` source trains a recommender directly from the [Google Analytics 4 Data API](https://developers.google.com/analytics/devguides/reporting/data/v1), skipping the BigQuery Export hop. Intended for properties that don't have BQ Export enabled.
+
+See `examples/ga4-data-api/` in the recotem repository for a working starting point.
+
+For properties that **do** have BQ Export enabled, the [BigQuery source](./bigquery) is usually a better fit — BigQuery scales further and exposes the full event payload.
+
+## Install
+
+```bash
+pip install "recotem[ga4]"
+```
+
+Without this extra, `recotem train` exits with:
+
+```
+DataSourceError: google-analytics-data is required for GA4Source. Install with: pip install 'recotem[ga4]'
+```
+
+## Authentication
+
+Application Default Credentials (ADC) only. No credentials are embedded in recipes. Configure one of:
+
+```bash
+# Local development
+gcloud auth application-default login
+
+# GKE — Workload Identity binding the pod's service account
+# to a Google service account. No env var setup needed.
+
+# Cloud Run / Cloud Functions
+# --service-account=<sa>@<project>.iam.gserviceaccount.com at deploy time
+
+# Service account key file (not recommended for production)
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+```
+
+The service account needs `roles/analytics.viewer` on the GA4 property.
+
+## Recipe configuration
+
+```yaml
+source:
+  type: ga4
+  property_id: "123456789"          # numeric, NOT the G-XXXX measurement ID
+  user_dimension: userPseudoId      # userPseudoId or userId
+  item_dimension: itemId            # itemId | itemName | itemCategory
+  time_dimension: date              # date | dateHour | dateHourMinute
+  event_names: [purchase, view_item, add_to_cart]
+  # Pick exactly one of (lookback_days) OR (start_date + end_date):
+  lookback_days: 90
+  # start_date: "2026-01-01"
+  # end_date:   "2026-05-01"
+  max_rows: 1_000_000               # required
+  weight_column: event_count
+  api_timeout_seconds: 60
+```
+
+| Field | Required | Default | Notes |
+|---|---|---|---|
+| `property_id` | yes | — | Numeric only (`^\d+$`). **Not** the `G-XXXX` measurement ID. |
+| `user_dimension` | yes | — | `userId` requires the User-ID feature to be configured on the property; `userPseudoId` is the cookie-bound default. |
+| `item_dimension` | no | `itemId` | Any GA4 item-scoped dimension. |
+| `time_dimension` | no | `date` | Granularity of the time bucket. `date` / `dateHour` / `dateHourMinute`. |
+| `event_names` | yes | — | 1–50 event names; each matches `^[A-Za-z_][A-Za-z0-9_]{0,39}$`. |
+| `lookback_days` | XOR | — | 1–3650. Rolling window ending at `yesterday` (the previous complete day in the property's timezone). |
+| `start_date` / `end_date` | XOR | — | ISO dates. Both required if either is set; `start_date <= end_date`. |
+| `max_rows` | yes | — | Hard cap on rows returned. Valid range `[1, 50_000_000]`. Out-of-range raises `ValidationError`. |
+| `weight_column` | no | `event_count` | Output DataFrame column name for the `eventCount` metric. Must match `schema.weight_column`. Validation rejects values that collide with `user_dimension`, `item_dimension`, `time_dimension`, or the literal `eventName` — a collision would silently overwrite a dimension in the per-row dict. |
+| `api_timeout_seconds` | no | `60` | Valid range `[5, 600]`. Out-of-range raises `ValidationError`. |
+
+::: warning Pick exactly one date-range form
+Set `lookback_days`, **or** set both `start_date` and `end_date`. Setting both forms — or neither — raises `ValidationError` at recipe load. `lookback_days` produces a rolling window ending at the previous complete day in the property's timezone (i.e. yesterday, not today).
+:::
+
+## How rows reach the DataFrame
+
+A GA4 request asks for four dimensions and one metric:
+
+```
+dimensions = [<user_dimension>, <item_dimension>, <time_dimension>, eventName]
+metric     = eventCount
+```
+
+The response is paginated (page size 100,000). Each row becomes a DataFrame row with the recipe-schema column names. The internal `eventName` column is dropped before `fetch()` returns, so multiple event types for the same `(user, item, time)` show up as multiple rows.
+
+::: warning Use `cleansing.dedup: none` for GA4
+The GA4 source returns one row per `(user, item, time, eventName)`. `keep_first` / `keep_last` would discard the weight from the other event types. irspack aggregates repeated `(user, item)` weights internally, so leaving them as separate rows is correct.
+:::
+
+## Quotas, pagination, retries
+
+- Page size 100,000 (Data API hard maximum).
+- The fetcher loops until `row_count` is drained, `max_rows` is hit, or `RECOTEM_GA4_MAX_PAGES` (default 500) is reached.
+- `RESOURCE_EXHAUSTED` / `UNAVAILABLE` gRPC codes are retried via `google.api_core.retry.Retry` (initial 1 s, exponential backoff up to 30 s, total budget = 3 × `api_timeout_seconds`).
+- `PERMISSION_DENIED` → immediate `DataSourceError` naming the role (`roles/analytics.viewer`) and the property ID.
+- All other `GoogleAPICallError` subclasses (e.g. `NOT_FOUND`, `INVALID_ARGUMENT`) → immediate `DataSourceError` carrying the API error class name and message.
+- A per-fetch wall-clock budget of `10 × api_timeout_seconds` bounds the entire paginated run. The deadline is checked **before** and **after** every `run_report` call, so an unlucky page that consumes the retry budget cannot overshoot by another full retry cycle.
+
+### Budget interaction
+
+The per-page `Retry(timeout=3 × api_timeout_seconds)` budget can in the worst case consume the full 3× wait before raising. Combined with the per-attempt `timeout=api_timeout_seconds`, a single page in worst-case retry can therefore burn ~`3 × api_timeout_seconds`. The outer 10× wall-clock budget is intentionally a circuit-breaker, not a generous cap: under sustained `RESOURCE_EXHAUSTED` back-pressure it will abort after roughly three exhausted pages rather than letting the run drift unboundedly. Tighten the query or raise `api_timeout_seconds` (which also raises the wall-clock budget linearly) if your workload legitimately requires more retried pages.
+
+## Environment variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `GOOGLE_APPLICATION_CREDENTIALS` | (unset) | ADC key file path. Empty = use the default chain (`gcloud` user creds → metadata server). |
+| `RECOTEM_GA4_MAX_PAGES` | `500` | Hard ceiling on pagination loops. Clamp `[1, 10_000]`. |
+| `RECOTEM_METRICS_ENABLED` | (unset) | Truthy emits `recotem_ga4_pages_fetched_total`, `recotem_ga4_rows_fetched_total`, and `recotem_ga4_quota_remaining` Prometheus metrics (requires `recotem[metrics]`). |
+
+## Troubleshooting
+
+| Error | Likely cause | Fix |
+|---|---|---|
+| `google-analytics-data is required for GA4Source. Install with: pip install 'recotem[ga4]'` | Missing extra. | `pip install "recotem[ga4]"` |
+| `GA4 access denied for property ...` | Service account lacks the role. | Grant `roles/analytics.viewer` on the GA4 property. |
+| `set exactly one of lookback_days OR (start_date + end_date)` | Both or neither set. | Pick one. |
+| `GA4 result exceeds max_rows=...` | Genuinely huge result. | Narrow `event_names` or shorten the window. |
+| `GA4 fetch reached max_pages=<n> without seeing a short page; increase RECOTEM_GA4_MAX_PAGES or tighten the query` | Property is too large for default ceiling. | Raise `RECOTEM_GA4_MAX_PAGES` after confirming quota. |
+
+## Notes
+
+- `recotem validate recipes/my_recipe.yaml` validates the ADC chain and the recipe schema before training. It does **not** issue a real Data API request — the property's quota is preserved.
+- Non-integer `eventCount` values surface as `DataSourceError` (exit 3) instead of a bare `ValueError`.
+- `GOOGLE_*` and `GCP_*` env vars are blacklisted from recipe `${...}` expansion. Cloud credentials must come from ADC, not from the recipe file.

--- a/docs/data-sources/sql.md
+++ b/docs/data-sources/sql.md
@@ -1,0 +1,187 @@
+---
+title: SQL Source
+---
+
+# SQL Source
+
+The `sql` source lets Recotem train recommenders directly from a relational database via [SQLAlchemy 2](https://www.sqlalchemy.org/). Supported dialects are PostgreSQL, MySQL/MariaDB, and SQLite. Other dialects are not supported and will raise `DataSourceError` at training time.
+
+See `examples/sql-sqlite/` in the recotem repository for a zero-cloud walkthrough.
+
+## Install
+
+```bash
+pip install "recotem[postgres]"   # PostgreSQL (via psycopg)
+pip install "recotem[mysql]"      # MySQL / MariaDB (via PyMySQL)
+pip install "recotem[sqlite]"     # SQLite (stdlib — no extra driver needed)
+```
+
+Without any of these extras, `recotem train` exits with:
+
+```
+DataSourceError: sqlalchemy is required for SQLSource. Install one of: recotem[postgres], recotem[mysql], recotem[sqlite].
+```
+
+## DSN injection (env var)
+
+The DSN is never written to the recipe. The recipe only names an environment variable; Recotem reads the DSN from that variable at training time.
+
+```bash
+export RECOTEM_RECIPE_DB_DSN="postgresql+psycopg://user:pass@host:5432/db?sslmode=require"
+uv run recotem train recipes/my_recipe.yaml
+```
+
+The variable name must match `^RECOTEM_RECIPE_[A-Z0-9_]+$`. Any other prefix is rejected at recipe load (`RecipeError`, exit 2).
+
+## Recipe configuration
+
+```yaml
+source:
+  type: sql
+  dsn_env: RECOTEM_RECIPE_DB_DSN
+  query: |
+    SELECT user_id, product_id, purchased_at
+    FROM orders
+    WHERE purchased_at >= :since
+      AND status = 'paid'
+  query_parameters:
+    since: ${RECOTEM_RECIPE_SINCE}
+  connect_timeout_seconds: 10
+  statement_timeout_seconds: 300
+```
+
+| Field | Required | Default | Notes |
+|---|---|---|---|
+| `dsn_env` | yes | — | Name of an env var matching `^RECOTEM_RECIPE_[A-Z0-9_]+$` containing the DSN. The DSN itself is never written to the recipe. |
+| `query` | yes | — | Raw SQL. Never subject to `${...}` expansion (SQL injection foreclosure). |
+| `query_parameters` | no | `{}` | Bound via SQLAlchemy `text().bindparams(...)`. Subject to `${RECOTEM_RECIPE_*}` expansion. |
+| `connect_timeout_seconds` | no | `10` | Valid range `[1, 60]`. Out-of-range raises `ValidationError`. Passed as `connect_timeout` (PG/MySQL) or `timeout` (SQLite). |
+| `statement_timeout_seconds` | no | `300` | Valid range `[1, 1800]`. See [Statement timeouts](#statement-timeouts) for per-dialect details. |
+
+## DSN examples
+
+| Dialect | DSN |
+|---|---|
+| PostgreSQL | `postgresql+psycopg://user:pass@host:5432/db?sslmode=require` |
+| MySQL / MariaDB | `mysql+pymysql://user:pass@host:3306/db?ssl=true` |
+| SQLite (file) | `sqlite:///absolute/path/to/file.db` |
+| SQLite (read-only) | `sqlite:///file:absolute/path/to/file.db?mode=ro&uri=true` |
+
+## Parameter binding
+
+Use SQLAlchemy named bind parameters (`:name`) for any value that varies between runs. Do **not** use Python string formatting or `${...}` expansion in `query` — the latter is explicitly blocked to foreclose SQL injection.
+
+```yaml
+source:
+  type: sql
+  dsn_env: RECOTEM_RECIPE_DB_DSN
+  query: |
+    SELECT user_id, item_id, ts
+    FROM events
+    WHERE ts >= :since
+      AND event_type = :event_type
+  query_parameters:
+    since: ${RECOTEM_RECIPE_SINCE}
+    event_type: purchase
+```
+
+Only `query_parameters` values undergo `${RECOTEM_RECIPE_*}` expansion. Both `query` and `dsn_env` are unconditionally exempt from expansion regardless of variable name.
+
+Parameter values are bound via SQLAlchemy `text().bindparams(...)`; supported types are `str`, `int`, `float`, and `bool`.
+
+## Read-only enforcement
+
+The DB user should have `SELECT`-only privileges on the relevant tables. Recotem also issues a session-level read-only command before running the query, as defence in depth:
+
+| Dialect | Statement |
+|---------|-----------|
+| PostgreSQL | `SET TRANSACTION READ ONLY` |
+| MySQL | `SET SESSION TRANSACTION READ ONLY` |
+| MariaDB | `SET SESSION TRANSACTION READ ONLY` + `SET SESSION max_statement_time = <seconds>` |
+| SQLite | `PRAGMA query_only = ON` |
+
+If this command fails (insufficient privilege, or the SQLite pragma cannot be set), training aborts with `DataSourceError`. It is **not** silently skipped. The authoritative trust boundary is still your grant model — never rely solely on the session flag.
+
+## Statement timeouts
+
+| Dialect | Implementation |
+|---------|----------------|
+| PostgreSQL | `SET LOCAL statement_timeout = <ms>` |
+| MySQL | `SET SESSION MAX_EXECUTION_TIME = <ms>` |
+| MariaDB | `SET SESSION max_statement_time = <seconds>` (different unit and variable from MySQL) |
+| SQLite | Not enforced; emits `sql_statement_timeout_unsupported_on_sqlite` structured warning. |
+
+On PostgreSQL, MySQL, and MariaDB, failure to set the timeout aborts training with `DataSourceError`. SQLite has no server-side timeout primitive — the warning is emitted so operators know the documented safety control is not in effect on this dialect.
+
+## TLS recommendations
+
+TLS is strongly recommended in production. Always set `sslmode=require` (or stricter: `verify-ca`, `verify-full`) on PostgreSQL, or `ssl=true` (or specify a CA bundle via `ssl_ca=...`) on MySQL/MariaDB. Recotem does not enforce TLS — but the source emits a `sql_dsn_tls_not_configured` structlog warning at init when the DSN appears plaintext:
+
+- PostgreSQL: no `sslmode` set, or set to `disable` / `allow` / `prefer`.
+- MySQL/MariaDB: no `ssl*` query parameter at all.
+
+Operators with deployment-level TLS (service mesh, sidecar) can silence the warning by adding the explicit DSN flag.
+
+## SSRF guard
+
+By default, DSN hosts that resolve to private / loopback / link-local IPs are rejected. The guard inspects every routing form the libpq / PyMySQL drivers honour — not just the URL netloc:
+
+- `url.host` (the netloc, e.g. `postgresql://u:p@host/db`).
+- `?host=name` (libpq for PostgreSQL, PyMySQL for MySQL/MariaDB) — when set, SQLAlchemy's `make_url` leaves `url.host` empty but the driver still routes the TCP connect to the query value.
+- `?hostaddr=ip` (libpq) — the actual TCP target IP. If both `host` and `hostaddr` are set, libpq uses `hostaddr` for the connect and `host` only for SNI / TLS certificate validation.
+
+Three routing forms are refused outright because they cannot be resolved to a TCP target the SSRF check can validate, and all amount to local pivots:
+
+- `?service=` (PostgreSQL) — libpq looks up parameters in `pg_service.conf`.
+- `?unix_socket=` (MySQL/MariaDB) — connects to a local Unix domain socket.
+- `?host=/abs/path` (PostgreSQL) — libpq treats absolute-path values as a Unix-socket directory.
+
+Network-dialect DSNs that contain *no* host information at all (e.g. `postgresql:///db`) are also refused, because libpq / PyMySQL would otherwise default to the local socket / `127.0.0.1`.
+
+::: warning Opt-in for in-cluster destinations
+Set `RECOTEM_SQL_ALLOW_PRIVATE=1` (also accepts `true` / `yes` / `on`) to opt in to any of the above. Intended for Docker Compose / Kubernetes service-name destinations, Unix-socket connections, or libpq service files. This env var **also disables the DNS-rebinding re-check** before each probe/fetch — opting in means trusting the host end-to-end.
+:::
+
+### DNS rebinding TOCTOU
+
+The SSRF check pins the **full set of resolved public IPs** (IPv4 + IPv6) at init across every candidate routing host. Before each probe/fetch, the effective TCP target (libpq: `hostaddr` > query `host` > netloc; PyMySQL: query `host` > netloc) is re-resolved via `socket.getaddrinfo`; if no address overlaps the pinned set, the run is aborted.
+
+This is a best-effort defence — the SQL driver does its own resolution at connect time, so a sufficiently fast attacker controlling DNS can still rebind between our check and the driver's resolution. Use platform controls (private network access, VPC peering, firewalls) as the authoritative boundary.
+
+## Environment variables
+
+| Variable | Default | Notes |
+|---|---|---|
+| `RECOTEM_RECIPE_*` | — | The env var whose name you set in `dsn_env`. |
+| `RECOTEM_MAX_SQL_ROWS` | `50_000_000` | Hard cap on rows returned by the query. Clamp `[1_000, 500_000_000]`. |
+| `RECOTEM_SQL_ALLOW_PRIVATE` | (unset) | Truthy values (`1`, `true`, `yes`, `on`) opt into private/loopback DSN hosts. |
+
+## Errors and exit codes
+
+| Error | Exit | Message pattern |
+|-------|------|----------------|
+| DSN env var not set or empty | 3 | `DataSourceError: env var RECOTEM_RECIPE_DB_DSN is not set or is empty; set it to the database DSN (e.g. postgresql://user:pass@host/db)` |
+| Unsupported dialect | 3 | `DataSourceError: unsupported SQL dialect 'oracle'; officially supported: ['mysql', 'postgres', 'sqlite'].` |
+| Missing driver for dialect | 3 | `DataSourceError: psycopg driver is required for dialect 'postgresql'. Install it with: pip install 'recotem[postgres]'` |
+| Query exceeds row cap | 3 | `DataSourceError: query result exceeds RECOTEM_MAX_SQL_ROWS=50000000 rows; tighten the query or raise the cap` |
+| Private/loopback host refused | 3 | `DataSourceError: refusing to connect to private/loopback host '10.0.0.5'; set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in (intended for in-cluster or compose service-name destinations)` |
+| libpq service-file routing refused | 3 | `DataSourceError: DSN routes via libpq service file (?service=...); this bypasses the network SSRF guard. Set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in.` |
+| MySQL Unix-socket routing refused | 3 | `DataSourceError: DSN routes via Unix socket (?unix_socket=...); this bypasses the network SSRF guard. Set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in.` |
+| Absolute-path host refused | 3 | `DataSourceError: DSN host is an absolute path (libpq Unix-socket form); this bypasses the network SSRF guard. Set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in.` |
+| Network DSN with no host refused | 3 | `DataSourceError: DSN for dialect 'postgresql' does not specify a host; the driver would default to the local socket / 127.0.0.1 which is rejected by the SSRF guard. Specify a host explicitly or set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in.` |
+| sqlalchemy not installed | 3 | `DataSourceError: sqlalchemy is required for SQLSource. Install one of: recotem[postgres], recotem[mysql], recotem[sqlite].` |
+| Column missing after query | 2 | `RecipeError: column 'item_id' not found in query result` |
+
+All SQL exceptions are wrapped in `DataSourceError` and produce exit 3. The full error type is included in the stderr JSON line. DSN userinfo is redacted from log output by `recotem.log_redaction`.
+
+## Notes
+
+- `recotem validate recipes/my_recipe.yaml` probes the database by issuing `SELECT 1` before training starts. This validates the DSN, driver installation, and host connectivity.
+- Query results are read in chunks to bound memory usage during streaming. The chunk size is `min(100_000, RECOTEM_MAX_SQL_ROWS)` so the row cap is enforced before the first chunk is fully loaded.
+
+::: warning Row cap is not a memory cap
+`RECOTEM_MAX_SQL_ROWS` caps the total **row count**, not the resulting DataFrame's resident memory. Chunks are accumulated into a list and concatenated at the end, so peak RAM is approximately `total_rows × bytes_per_row`. Trainers with the default cap (50 M rows) should expect ~2.5–5 GiB resident under wide-result queries; with the upper clamp (500 M rows) the same query can require 25 GiB+ of RAM. Tighten the cap or the query columns if you need a memory bound, not just a row bound. Server-side streaming via `stream_results=True` controls only the **wire-level** cursor; the row cap is the right knob for the consumer-side bound.
+:::
+
+- `source.query` and `source.dsn_env` are unconditionally exempt from `${...}` expansion regardless of variable name; only `query_parameters` values are expanded.
+- `flock` is host-local; across hosts use scheduler-level mutex (`concurrencyPolicy: Forbid` in Kubernetes CronJobs).

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,7 +44,7 @@ A recipe is the single source of truth for a model:
 ```
 
 The recipe captures:
-- **Where to get data** (`source` block — CSV, Parquet, BigQuery, or plugin)
+- **Where to get data** (`source` block — CSV, Parquet, BigQuery, SQL, GA4, or plugin)
 - **How to map columns** (`schema` block — user ID, item ID, optional timestamp)
 - **Data quality gates** (`cleansing` block — null-drop, dedup, minimum thresholds)
 - **What to train** (`training` block — algorithms, Optuna budget, split scheme)
@@ -148,6 +148,8 @@ This separation means:
 - [Recipe Reference](./recipe-reference) — every recipe field, type, default, and validation rule
 - [CSV / Parquet Source](./data-sources/csv) — local, object-storage, and HTTP source options
 - [BigQuery Source](./data-sources/bigquery) — authentication, parameter binding, GA4 patterns
+- [SQL Source](./data-sources/sql) — PostgreSQL / MySQL / MariaDB / SQLite via SQLAlchemy 2
+- [GA4 Source](./data-sources/ga4) — Google Analytics 4 Data API, skipping the BigQuery Export hop
 - [Plugin Data Sources](./data-sources/plugins) — extend `source.type` with custom plugins
 - Deployment guides — Docker, Kubernetes, cron scheduling
 - Operations — key rotation, recovery, sizing, troubleshooting

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -11,7 +11,7 @@ A recipe is a YAML file that defines what data to fetch, how to train, and where
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | string | yes | Endpoint name. Pattern: `^[A-Za-z0-9_-]{1,64}$`. Becomes `/predict/{name}`. |
-| `source` | object | yes | Data source config. `type` field is the discriminator (`csv`, `parquet`, `bigquery`, or any plugin). Validated in two stages: the rest of the recipe is parsed first, then the source dict is dispatched to the plugin's `Config` class. As a result, errors in `source.*` surface *after* errors elsewhere in the recipe; an unknown `source.type` raises a `DataSourceError` listing all registered type names. |
+| `source` | object | yes | Data source config. `type` field is the discriminator (`csv`, `parquet`, `bigquery`, `sql`, `ga4`, or any plugin). Validated in two stages: the rest of the recipe is parsed first, then the source dict is dispatched to the plugin's `Config` class. As a result, errors in `source.*` surface *after* errors elsewhere in the recipe; an unknown `source.type` raises a `DataSourceError` listing all registered type names. |
 | `schema` | object | yes | Column mapping. |
 | `cleansing` | object | no | Data quality gates. |
 | `item_metadata` | object | no | Metadata joined into predict responses. |
@@ -73,6 +73,63 @@ source:
 Install the extra: `pip install "recotem[bigquery]"`.
 
 Environment variable expansion is **never** performed inside `query` or `query_parameters`. Use `@param` placeholders to keep SQL injection foreclosed.
+
+### `source.type: sql`
+
+```yaml
+source:
+  type: sql
+  dsn_env: RECOTEM_RECIPE_DB_DSN
+  query: |
+    SELECT user_id, item_id, ts
+    FROM events
+    WHERE ts >= :since
+  query_parameters:
+    since: ${RECOTEM_RECIPE_SINCE}
+  connect_timeout_seconds: 10
+  statement_timeout_seconds: 300
+```
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `dsn_env` | string | required | Name of an env var matching `^RECOTEM_RECIPE_[A-Z0-9_]+$` containing the DSN. The DSN itself is never written to the recipe. |
+| `query` | string | required | Raw SQL. Trusted code — not env-expanded. Use `:name` for dynamic values. |
+| `query_parameters` | map | `{}` | Bound via SQLAlchemy `text().bindparams(...)`. Subject to `${RECOTEM_RECIPE_*}` expansion. |
+| `connect_timeout_seconds` | int | `10` | Valid range `[1, 60]`. |
+| `statement_timeout_seconds` | int | `300` | Valid range `[1, 1800]`. Per-dialect implementation — see [SQL source](./data-sources/sql#statement-timeouts). |
+
+Install one extra: `pip install "recotem[postgres]"`, `recotem[mysql]`, or `recotem[sqlite]`. Full reference: [SQL source](./data-sources/sql).
+
+### `source.type: ga4`
+
+```yaml
+source:
+  type: ga4
+  property_id: "123456789"
+  user_dimension: userPseudoId
+  item_dimension: itemId
+  time_dimension: date
+  event_names: [purchase, view_item, add_to_cart]
+  lookback_days: 90               # XOR with start_date + end_date
+  max_rows: 1_000_000
+  weight_column: event_count
+  api_timeout_seconds: 60
+```
+
+| Field | Type | Default | Notes |
+|-------|------|---------|-------|
+| `property_id` | string | required | Numeric only (`^\d+$`). Not the `G-XXXX` measurement ID. |
+| `user_dimension` | string | required | `userId` or `userPseudoId`. |
+| `item_dimension` | string | `itemId` | Any GA4 item-scoped dimension. |
+| `time_dimension` | string | `date` | `date` / `dateHour` / `dateHourMinute`. |
+| `event_names` | list[string] | required | 1–50 names; each matches `^[A-Za-z_][A-Za-z0-9_]{0,39}$`. |
+| `lookback_days` | int | XOR | 1–3650. Rolling window ending yesterday. |
+| `start_date` / `end_date` | string (ISO) | XOR | Both required if either is set. |
+| `max_rows` | int | required | Valid range `[1, 50_000_000]`. |
+| `weight_column` | string | `event_count` | Must not collide with the dimension keys or the literal `eventName`. |
+| `api_timeout_seconds` | int | `60` | Valid range `[5, 600]`. |
+
+Install the extra: `pip install "recotem[ga4]"`. Full reference: [GA4 source](./data-sources/ga4).
 
 ---
 

--- a/ja/docs/data-sources/ga4.md
+++ b/ja/docs/data-sources/ga4.md
@@ -1,0 +1,131 @@
+---
+title: GA4 ソース
+---
+
+# GA4 ソース
+
+`ga4` ソースは [Google Analytics 4 Data API](https://developers.google.com/analytics/devguides/reporting/data/v1) から直接 Recotem の学習を実行できるようにします。BigQuery Export を経由しません。BQ Export を有効にしていないプロパティ向けです。
+
+動作する出発点としては recotem リポジトリの `examples/ga4-data-api/` を参照してください。
+
+BQ Export が**有効**なプロパティでは通常 [BigQuery ソース](./bigquery) のほうが適しています — BigQuery はよりスケールし、イベントペイロード全体を扱えます。
+
+## インストール
+
+```bash
+pip install "recotem[ga4]"
+```
+
+このエクストラなしで `recotem train` を実行すると、以下のメッセージで終了します:
+
+```
+DataSourceError: google-analytics-data is required for GA4Source. Install with: pip install 'recotem[ga4]'
+```
+
+## 認証
+
+Application Default Credentials (ADC) のみ。レシピに認証情報を埋め込みません。以下のいずれかを設定してください:
+
+```bash
+# ローカル開発
+gcloud auth application-default login
+
+# GKE — Pod のサービスアカウントを Google サービスアカウントにバインドする
+# Workload Identity。環境変数の設定は不要。
+
+# Cloud Run / Cloud Functions
+# デプロイ時に --service-account=<sa>@<project>.iam.gserviceaccount.com
+
+# サービスアカウントキーファイル (本番環境では非推奨)
+export GOOGLE_APPLICATION_CREDENTIALS=/path/to/key.json
+```
+
+サービスアカウントには GA4 プロパティに対する `roles/analytics.viewer` が必要です。
+
+## レシピ設定
+
+```yaml
+source:
+  type: ga4
+  property_id: "123456789"          # 数値のプロパティ ID。G-XXXX 形式の測定 ID ではない
+  user_dimension: userPseudoId      # userPseudoId または userId
+  item_dimension: itemId            # itemId | itemName | itemCategory
+  time_dimension: date              # date | dateHour | dateHourMinute
+  event_names: [purchase, view_item, add_to_cart]
+  # lookback_days か (start_date + end_date) の正確に一方のみを指定:
+  lookback_days: 90
+  # start_date: "2026-01-01"
+  # end_date:   "2026-05-01"
+  max_rows: 1_000_000               # 必須
+  weight_column: event_count
+  api_timeout_seconds: 60
+```
+
+| フィールド | 必須 | デフォルト | 備考 |
+|------------|------|-----------|------|
+| `property_id` | yes | — | 数値のみ (`^\d+$`)。`G-XXXX` 形式の測定 ID では**ありません**。 |
+| `user_dimension` | yes | — | `userId` を使うにはプロパティで User-ID 機能の設定が必要。`userPseudoId` はクッキーベースのデフォルト。 |
+| `item_dimension` | no | `itemId` | GA4 のアイテムスコープのディメンション。 |
+| `time_dimension` | no | `date` | 時刻バケットの粒度。`date` / `dateHour` / `dateHourMinute`。 |
+| `event_names` | yes | — | 1〜50 個のイベント名。各値は `^[A-Za-z_][A-Za-z0-9_]{0,39}$` に一致。 |
+| `lookback_days` | XOR | — | 1〜3650 日。プロパティのタイムゾーンにおける前日 (昨日) で終わるローリングウィンドウ。 |
+| `start_date` / `end_date` | XOR | — | ISO 形式の日付。いずれかを設定する場合は両方必須。`start_date <= end_date`。 |
+| `max_rows` | yes | — | 返却される行数のハードキャップ。有効範囲 `[1, 50_000_000]`。範囲外は `ValidationError`。 |
+| `weight_column` | no | `event_count` | `eventCount` メトリックの出力 DataFrame カラム名。`schema.weight_column` と一致する必要があります。`user_dimension`、`item_dimension`、`time_dimension`、または `eventName` という値と衝突する値は拒否されます — 衝突するとディメンションが暗黙的に上書きされてしまうためです。 |
+| `api_timeout_seconds` | no | `60` | 有効範囲 `[5, 600]`。範囲外は `ValidationError`。 |
+
+::: warning 日付範囲の指定方式は正確に 1 つ
+`lookback_days` を設定する**か**、`start_date` と `end_date` の両方を設定してください。両方の方式を設定したり、どちらも設定しなかった場合はレシピロード時に `ValidationError` が発生します。`lookback_days` はプロパティのタイムゾーンにおける直前の完了日 (つまり昨日、今日ではない) で終わるローリングウィンドウを生成します。
+:::
+
+## 行が DataFrame に到達する流れ
+
+GA4 リクエストは 4 つのディメンションと 1 つのメトリックを要求します:
+
+```
+dimensions = [<user_dimension>, <item_dimension>, <time_dimension>, eventName]
+metric     = eventCount
+```
+
+レスポンスはページング (ページサイズ 100,000) されます。各行はレシピのスキーマのカラム名で DataFrame の 1 行になります。内部の `eventName` カラムは `fetch()` がリターンする前に削除されるため、同じ `(user, item, time)` に対する複数のイベント種別は複数の行として現れます。
+
+::: warning GA4 では `cleansing.dedup: none` を使用してください
+GA4 ソースは `(user, item, time, eventName)` ごとに 1 行を返します。`keep_first` / `keep_last` は他のイベント種別の重みを破棄してしまいます。irspack は内部で重複する `(user, item)` の重みを集約するため、別々の行のままにしておくのが正しい挙動です。
+:::
+
+## クォータ、ページング、リトライ
+
+- ページサイズ 100,000 (Data API のハード最大値)。
+- フェッチャは `row_count` が枯渇するか、`max_rows` に到達するか、`RECOTEM_GA4_MAX_PAGES` (デフォルト 500) に達するまでループします。
+- `RESOURCE_EXHAUSTED` / `UNAVAILABLE` の gRPC コードは `google.api_core.retry.Retry` 経由でリトライされます (初期 1 秒、最大 30 秒までの指数バックオフ、総バジェット = 3 × `api_timeout_seconds`)。
+- `PERMISSION_DENIED` → 即座に `DataSourceError` を発生し、必要なロール (`roles/analytics.viewer`) とプロパティ ID をメッセージに含めます。
+- その他の `GoogleAPICallError` サブクラス (例: `NOT_FOUND`、`INVALID_ARGUMENT`) → 即座に `DataSourceError` を発生し、API エラーのクラス名とメッセージを保持します。
+- 1 回の取得あたりの実時間バジェット `10 × api_timeout_seconds` がページング処理全体を制限します。デッドラインは `run_report` 呼び出しの**前**と**後**の両方でチェックされるため、リトライバジェットを消費した不運なページが追加のリトライサイクル 1 つ分超過することはありません。
+
+### バジェットの相互作用
+
+ページごとの `Retry(timeout=3 × api_timeout_seconds)` バジェットは、最悪ケースでは発生まで 3× の待機時間をすべて消費する可能性があります。試行ごとの `timeout=api_timeout_seconds` と組み合わせると、最悪ケースで 1 ページが約 `3 × api_timeout_seconds` を消費する可能性があります。外側の 10× 実時間バジェットは意図的にサーキットブレーカーであり、緩い上限ではありません: 持続的な `RESOURCE_EXHAUSTED` の背圧下では、無制限に実行がドリフトすることを許さず、おおよそ 3 ページ消費した時点で中断します。ワークロードがより多くのリトライページを正当に必要とする場合はクエリを絞るか、`api_timeout_seconds` を上げてください (実時間バジェットも線形に増加します)。
+
+## 環境変数
+
+| 変数 | デフォルト | 備考 |
+|------|-----------|------|
+| `GOOGLE_APPLICATION_CREDENTIALS` | (未設定) | ADC キーファイルのパス。空 = デフォルトチェーン (`gcloud` ユーザー認証情報 → メタデータサーバー) を使用。 |
+| `RECOTEM_GA4_MAX_PAGES` | `500` | ページングループのハード上限。クランプ範囲 `[1, 10_000]`。 |
+| `RECOTEM_METRICS_ENABLED` | (未設定) | 真の値で `recotem_ga4_pages_fetched_total`、`recotem_ga4_rows_fetched_total`、`recotem_ga4_quota_remaining` の Prometheus メトリクスを公開 (`recotem[metrics]` が必要)。 |
+
+## トラブルシューティング
+
+| エラー | 想定される原因 | 対処 |
+|--------|--------------|------|
+| `google-analytics-data is required for GA4Source. Install with: pip install 'recotem[ga4]'` | エクストラ未インストール。 | `pip install "recotem[ga4]"` |
+| `GA4 access denied for property ...` | サービスアカウントにロールが付与されていない。 | GA4 プロパティに `roles/analytics.viewer` を付与してください。 |
+| `set exactly one of lookback_days OR (start_date + end_date)` | 両方または両方が未設定。 | どちらか一方を選択してください。 |
+| `GA4 result exceeds max_rows=...` | 結果が本当に巨大。 | `event_names` を絞るかウィンドウを短くしてください。 |
+| `GA4 fetch reached max_pages=<n> without seeing a short page; increase RECOTEM_GA4_MAX_PAGES or tighten the query` | プロパティがデフォルト上限に対して大きすぎる。 | クォータを確認の上で `RECOTEM_GA4_MAX_PAGES` を引き上げてください。 |
+
+## 備考
+
+- `recotem validate recipes/my_recipe.yaml` は学習開始前に ADC チェーンとレシピスキーマを検証します。実際の Data API リクエストは発行**しません** — プロパティのクォータは保持されます。
+- 整数でない `eventCount` 値は生の `ValueError` (終了コード 1) ではなく `DataSourceError` (終了コード 3) として表面化します。
+- `GOOGLE_*` および `GCP_*` 環境変数はレシピの `${...}` 展開からブラックリストされています。クラウド認証情報はレシピファイルではなく ADC から提供する必要があります。

--- a/ja/docs/data-sources/sql.md
+++ b/ja/docs/data-sources/sql.md
@@ -1,0 +1,187 @@
+---
+title: SQL ソース
+---
+
+# SQL ソース
+
+`sql` ソースは [SQLAlchemy 2](https://www.sqlalchemy.org/) 経由でリレーショナルデータベースから直接 Recotem の学習を実行できるようにします。対応するダイアレクトは PostgreSQL、MySQL/MariaDB、SQLite です。それ以外のダイアレクトはサポートされておらず、学習時に `DataSourceError` が発生します。
+
+クラウドを使わないウォークスルーは recotem リポジトリの `examples/sql-sqlite/` を参照してください。
+
+## インストール
+
+```bash
+pip install "recotem[postgres]"   # PostgreSQL (psycopg 経由)
+pip install "recotem[mysql]"      # MySQL / MariaDB (PyMySQL 経由)
+pip install "recotem[sqlite]"     # SQLite (stdlib — 追加ドライバ不要)
+```
+
+これらのエクストラなしで `recotem train` を実行すると、以下のメッセージで終了します:
+
+```
+DataSourceError: sqlalchemy is required for SQLSource. Install one of: recotem[postgres], recotem[mysql], recotem[sqlite].
+```
+
+## DSN の注入 (環境変数経由)
+
+DSN がレシピに書き込まれることはありません。レシピには環境変数名のみを記述し、Recotem は学習時にその変数から DSN を読み取ります。
+
+```bash
+export RECOTEM_RECIPE_DB_DSN="postgresql+psycopg://user:pass@host:5432/db?sslmode=require"
+uv run recotem train recipes/my_recipe.yaml
+```
+
+変数名は `^RECOTEM_RECIPE_[A-Z0-9_]+$` に一致する必要があります。それ以外のプレフィックスはレシピロード時に拒否されます (`RecipeError`、終了コード 2)。
+
+## レシピ設定
+
+```yaml
+source:
+  type: sql
+  dsn_env: RECOTEM_RECIPE_DB_DSN
+  query: |
+    SELECT user_id, product_id, purchased_at
+    FROM orders
+    WHERE purchased_at >= :since
+      AND status = 'paid'
+  query_parameters:
+    since: ${RECOTEM_RECIPE_SINCE}
+  connect_timeout_seconds: 10
+  statement_timeout_seconds: 300
+```
+
+| フィールド | 必須 | デフォルト | 備考 |
+|------------|------|-----------|------|
+| `dsn_env` | yes | — | DSN を保持する環境変数の名前。`^RECOTEM_RECIPE_[A-Z0-9_]+$` に一致する必要があります。DSN 自体がレシピに書き込まれることはありません。 |
+| `query` | yes | — | 生の SQL。変数名に関わらず `${...}` 展開は**決して**行われません (SQL インジェクションの防止)。 |
+| `query_parameters` | no | `{}` | SQLAlchemy の `text().bindparams(...)` 経由でバインドされます。`${RECOTEM_RECIPE_*}` 展開の対象です。 |
+| `connect_timeout_seconds` | no | `10` | 有効範囲 `[1, 60]`。範囲外は `ValidationError`。PG/MySQL では `connect_timeout`、SQLite では `timeout` として渡されます。 |
+| `statement_timeout_seconds` | no | `300` | 有効範囲 `[1, 1800]`。ダイアレクト別の詳細は [ステートメントタイムアウト](#ステートメントタイムアウト) を参照してください。 |
+
+## DSN の例
+
+| ダイアレクト | DSN |
+|--------------|-----|
+| PostgreSQL | `postgresql+psycopg://user:pass@host:5432/db?sslmode=require` |
+| MySQL / MariaDB | `mysql+pymysql://user:pass@host:3306/db?ssl=true` |
+| SQLite (ファイル) | `sqlite:///absolute/path/to/file.db` |
+| SQLite (読み取り専用) | `sqlite:///file:absolute/path/to/file.db?mode=ro&uri=true` |
+
+## パラメータバインド
+
+実行間で変動する値には SQLAlchemy の名前付きバインドパラメータ (`:name`) を使用してください。`query` に Python の文字列フォーマットや `${...}` 展開を使用**しないでください** — 後者は SQL インジェクションを防ぐために明示的にブロックされています。
+
+```yaml
+source:
+  type: sql
+  dsn_env: RECOTEM_RECIPE_DB_DSN
+  query: |
+    SELECT user_id, item_id, ts
+    FROM events
+    WHERE ts >= :since
+      AND event_type = :event_type
+  query_parameters:
+    since: ${RECOTEM_RECIPE_SINCE}
+    event_type: purchase
+```
+
+`${RECOTEM_RECIPE_*}` 展開は `query_parameters` の値に対してのみ行われます。`query` と `dsn_env` は変数名に関わらず展開から無条件に除外されます。
+
+パラメータ値は SQLAlchemy の `text().bindparams(...)` でバインドされます。対応する型は `str`、`int`、`float`、`bool` です。
+
+## 読み取り専用の強制
+
+DB ユーザーには対象テーブルに対する `SELECT` 権限のみを付与してください。Recotem は多層防御として、クエリ実行前にセッションレベルの読み取り専用コマンドも発行します:
+
+| ダイアレクト | ステートメント |
+|--------------|--------------|
+| PostgreSQL | `SET TRANSACTION READ ONLY` |
+| MySQL | `SET SESSION TRANSACTION READ ONLY` |
+| MariaDB | `SET SESSION TRANSACTION READ ONLY` + `SET SESSION max_statement_time = <seconds>` |
+| SQLite | `PRAGMA query_only = ON` |
+
+このコマンドが失敗した場合 (権限不足、または SQLite で pragma が設定できない場合)、学習は `DataSourceError` で中断します。**暗黙的にスキップされることはありません**。最終的な信頼境界は依然として GRANT モデルにあります — セッションフラグのみに依存しないでください。
+
+## ステートメントタイムアウト
+
+| ダイアレクト | 実装 |
+|--------------|------|
+| PostgreSQL | `SET LOCAL statement_timeout = <ms>` |
+| MySQL | `SET SESSION MAX_EXECUTION_TIME = <ms>` |
+| MariaDB | `SET SESSION max_statement_time = <seconds>` (MySQL と単位・変数名が異なる) |
+| SQLite | 強制されない。`sql_statement_timeout_unsupported_on_sqlite` 構造化警告を出力。 |
+
+PostgreSQL、MySQL、MariaDB ではタイムアウト設定が失敗すると学習が `DataSourceError` で中断します。SQLite にはサーバーサイドのタイムアウトプリミティブがないため、このダイアレクトでは文書化された安全制御が機能しないことをオペレーターに知らせるために警告が出力されます。
+
+## TLS 推奨事項
+
+本番環境では TLS を強く推奨します。PostgreSQL では `sslmode=require` (またはより厳しい `verify-ca` / `verify-full`) を必ず設定してください。MySQL/MariaDB では `ssl=true` (または `ssl_ca=...` で CA バンドルを指定) を設定してください。Recotem は TLS を強制しませんが、DSN が平文に見える場合に init 時に `sql_dsn_tls_not_configured` 構造化警告を出力します:
+
+- PostgreSQL: `sslmode` が未設定、または `disable` / `allow` / `prefer` に設定されている。
+- MySQL/MariaDB: `ssl*` クエリパラメータが全くない。
+
+デプロイメントレベル (サービスメッシュ、サイドカー) で TLS を実装しているオペレーターは、明示的な DSN フラグを追加することで警告を抑止できます。
+
+## SSRF ガード
+
+デフォルトでは、プライベート / ループバック / リンクローカル IP に解決される DSN ホストは拒否されます。ガードは libpq / PyMySQL ドライバが解釈するすべてのルーティング形式を検査します — URL の netloc だけではありません:
+
+- `url.host` (netloc、例: `postgresql://u:p@host/db`)。
+- `?host=name` (PostgreSQL の libpq、MySQL/MariaDB の PyMySQL) — 設定された場合、SQLAlchemy の `make_url` は `url.host` を空にしますが、ドライバは TCP 接続をクエリ値にルーティングします。
+- `?hostaddr=ip` (libpq) — 実際の TCP ターゲット IP。`host` と `hostaddr` の両方が設定された場合、libpq は `hostaddr` を接続に使用し、`host` は SNI / TLS 証明書検証にのみ使用します。
+
+3 つのルーティング形式は SSRF チェックでターゲット TCP に解決できず、すべてローカルへのピボットに相当するため、初めから拒否されます:
+
+- `?service=` (PostgreSQL) — libpq が `pg_service.conf` でパラメータを参照する。
+- `?unix_socket=` (MySQL/MariaDB) — ローカル Unix ドメインソケットに接続する。
+- `?host=/abs/path` (PostgreSQL) — libpq は絶対パス値を Unix ソケットディレクトリとして扱う。
+
+ホスト情報をまったく含まないネットワークダイアレクトの DSN (例: `postgresql:///db`) も拒否されます。libpq / PyMySQL がローカルソケット / `127.0.0.1` にデフォルトしてしまうためです。
+
+::: warning クラスタ内宛先へのオプトイン
+`RECOTEM_SQL_ALLOW_PRIVATE=1` (`true` / `yes` / `on` も受け付けます) を設定することで上記の制限をオプトインできます。Docker Compose / Kubernetes のサービス名宛先、Unix ソケット接続、libpq サービスファイル向けの設定です。この環境変数は各 probe/fetch の前の **DNS リバインディング再チェックも無効化** します — オプトインはホストをエンドツーエンドで信頼することを意味します。
+:::
+
+### DNS リバインディング TOCTOU
+
+SSRF チェックは init 時にすべての候補ルーティングホストにわたって **解決された公開 IP の完全な集合** (IPv4 + IPv6) をピン留めします。各 probe/fetch の前に、有効な TCP ターゲット (libpq: `hostaddr` > クエリ `host` > netloc、PyMySQL: クエリ `host` > netloc) を `socket.getaddrinfo` で再解決し、ピン留めされた集合と重なるアドレスがなければ実行を中断します。
+
+これはベストエフォートの防御です — SQL ドライバは接続時に独自の解決を行うため、DNS を制御する十分に高速な攻撃者は、Recotem のチェックとドライバの解決の間にリバインドできます。プラットフォームレベルの制御 (プライベートネットワークアクセス、VPC ピアリング、ファイアウォール) を最終的な信頼境界として使用してください。
+
+## 環境変数
+
+| 変数 | デフォルト | 備考 |
+|------|-----------|------|
+| `RECOTEM_RECIPE_*` | — | `dsn_env` で名前を指定した環境変数。 |
+| `RECOTEM_MAX_SQL_ROWS` | `50_000_000` | クエリが返す行数のハードキャップ。クランプ範囲 `[1_000, 500_000_000]`。 |
+| `RECOTEM_SQL_ALLOW_PRIVATE` | (未設定) | 真の値 (`1`、`true`、`yes`、`on`) でプライベート / ループバック DSN ホストにオプトイン。 |
+
+## エラーと終了コード
+
+| エラー | 終了コード | メッセージパターン |
+|--------|-----------|------------------|
+| DSN 環境変数が未設定または空 | 3 | `DataSourceError: env var RECOTEM_RECIPE_DB_DSN is not set or is empty; set it to the database DSN (e.g. postgresql://user:pass@host/db)` |
+| 未対応のダイアレクト | 3 | `DataSourceError: unsupported SQL dialect 'oracle'; officially supported: ['mysql', 'postgres', 'sqlite'].` |
+| ダイアレクトのドライバ不在 | 3 | `DataSourceError: psycopg driver is required for dialect 'postgresql'. Install it with: pip install 'recotem[postgres]'` |
+| 行数上限超過 | 3 | `DataSourceError: query result exceeds RECOTEM_MAX_SQL_ROWS=50000000 rows; tighten the query or raise the cap` |
+| プライベート / ループバックホストの拒否 | 3 | `DataSourceError: refusing to connect to private/loopback host '10.0.0.5'; set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in (intended for in-cluster or compose service-name destinations)` |
+| libpq サービスファイル経由のルーティング拒否 | 3 | `DataSourceError: DSN routes via libpq service file (?service=...); this bypasses the network SSRF guard. Set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in.` |
+| MySQL Unix ソケット経由のルーティング拒否 | 3 | `DataSourceError: DSN routes via Unix socket (?unix_socket=...); this bypasses the network SSRF guard. Set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in.` |
+| 絶対パスホストの拒否 | 3 | `DataSourceError: DSN host is an absolute path (libpq Unix-socket form); this bypasses the network SSRF guard. Set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in.` |
+| ホスト情報のないネットワーク DSN 拒否 | 3 | `DataSourceError: DSN for dialect 'postgresql' does not specify a host; the driver would default to the local socket / 127.0.0.1 which is rejected by the SSRF guard. Specify a host explicitly or set RECOTEM_SQL_ALLOW_PRIVATE=1 to opt in.` |
+| sqlalchemy 未インストール | 3 | `DataSourceError: sqlalchemy is required for SQLSource. Install one of: recotem[postgres], recotem[mysql], recotem[sqlite].` |
+| クエリ後のカラム不在 | 2 | `RecipeError: column 'item_id' not found in query result` |
+
+すべての SQL 例外は `DataSourceError` にラップされて終了コード 3 になります。完全なエラータイプは stderr の JSON 行に含まれます。DSN の userinfo は `recotem.log_redaction` によってログ出力から取り除かれます。
+
+## 備考
+
+- `recotem validate recipes/my_recipe.yaml` は学習開始前に `SELECT 1` を発行してデータベースをプローブします。これにより DSN、ドライバのインストール状況、ホストへの接続性が検証されます。
+- クエリ結果はストリーミング時のメモリ使用量を抑えるためにチャンク単位で読み込まれます。チャンクサイズは `min(100_000, RECOTEM_MAX_SQL_ROWS)` であり、最初のチャンクがフルにロードされる前に行数上限が強制されます。
+
+::: warning 行数上限はメモリ上限ではありません
+`RECOTEM_MAX_SQL_ROWS` は総**行数**を上限とするのみで、生成される DataFrame の常駐メモリは制限しません。チャンクはリストに蓄積されて最後に連結されるため、ピーク RAM はおおよそ `total_rows × bytes_per_row` です。デフォルトの上限 (5,000 万行) ではワイドな結果クエリで 2.5〜5 GiB の常駐メモリを想定してください。上限クランプ (5 億行) では同じクエリが 25 GiB 以上の RAM を必要とする可能性があります。行数の上限だけでなくメモリの上限が必要な場合は、上限値を厳しくするかクエリのカラムを減らしてください。`stream_results=True` によるサーバーサイドストリーミングは**ワイヤレベル**のカーソルのみを制御します。コンシューマーサイドの上限には行数上限を使用してください。
+:::
+
+- `source.query` および `source.dsn_env` は変数名に関わらず `${...}` 展開から無条件に除外されます。展開対象は `query_parameters` の値のみです。
+- `flock` はホストローカルです。ホストをまたぐ場合はスケジューラレベルのミューテックスを使用してください (Kubernetes CronJob では `concurrencyPolicy: Forbid`)。

--- a/ja/docs/index.md
+++ b/ja/docs/index.md
@@ -44,7 +44,7 @@ Recotem はレシピ駆動の推薦システムです。単一の YAML ファイ
 ```
 
 レシピが記述する内容:
-- **データの取得先** (`source` ブロック — CSV、Parquet、BigQuery、またはプラグイン)
+- **データの取得先** (`source` ブロック — CSV、Parquet、BigQuery、SQL、GA4、またはプラグイン)
 - **カラムのマッピング** (`schema` ブロック — ユーザー ID、アイテム ID、任意のタイムスタンプ)
 - **データ品質ゲート** (`cleansing` ブロック — null 除去、重複除去、最低閾値)
 - **学習内容** (`training` ブロック — アルゴリズム、Optuna バジェット、分割方式)
@@ -148,6 +148,8 @@ artifacts/news_articles.<sha8>.recotem
 - [レシピリファレンス](./recipe-reference) — レシピの全フィールド、型、デフォルト値、バリデーションルール
 - [CSV / Parquet ソース](./data-sources/csv) — ローカル、オブジェクトストレージ、HTTP ソースのオプション
 - [BigQuery ソース](./data-sources/bigquery) — 認証、パラメータバインド、GA4 パターン
+- [SQL ソース](./data-sources/sql) — SQLAlchemy 2 経由の PostgreSQL / MySQL / MariaDB / SQLite
+- [GA4 ソース](./data-sources/ga4) — BigQuery Export を経由しない Google Analytics 4 Data API
 - [プラグインデータソース](./data-sources/plugins) — カスタムプラグインによる `source.type` の拡張
 - デプロイガイド — Docker、Kubernetes、cron スケジューリング
 - 運用ガイド — 鍵ローテーション、リカバリ、サイジング、トラブルシューティング

--- a/ja/docs/recipe-reference.md
+++ b/ja/docs/recipe-reference.md
@@ -11,7 +11,7 @@ title: レシピリファレンス
 | フィールド | 型 | 必須 | 説明 |
 |------------|-----|------|------|
 | `name` | string | yes | エンドポイント名。パターン: `^[A-Za-z0-9_-]{1,64}$`。`/predict/{name}` になります。 |
-| `source` | object | yes | データソース設定。`type` フィールドが識別子 (`csv`、`parquet`、`bigquery`、またはプラグイン)。バリデーションは 2 段階: まずレシピの残りの部分がパースされ、次にソースの dict がプラグインの `Config` クラスに振り分けられます。そのため `source.*` のエラーは他のフィールドのエラーの*後*に表示されます。不明な `source.type` は登録済みの全型名を列挙した `DataSourceError` を発生させます。 |
+| `source` | object | yes | データソース設定。`type` フィールドが識別子 (`csv`、`parquet`、`bigquery`、`sql`、`ga4`、またはプラグイン)。バリデーションは 2 段階: まずレシピの残りの部分がパースされ、次にソースの dict がプラグインの `Config` クラスに振り分けられます。そのため `source.*` のエラーは他のフィールドのエラーの*後*に表示されます。不明な `source.type` は登録済みの全型名を列挙した `DataSourceError` を発生させます。 |
 | `schema` | object | yes | カラムマッピング。 |
 | `cleansing` | object | no | データ品質ゲート。 |
 | `item_metadata` | object | no | predict レスポンスに結合するメタデータ。 |
@@ -73,6 +73,63 @@ source:
 エクストラのインストール: `pip install "recotem[bigquery]"`。
 
 `query` や `query_parameters` の内部では環境変数展開は**決して**行われません。SQL インジェクションを防ぐために `@param` プレースホルダーを使用してください。
+
+### `source.type: sql`
+
+```yaml
+source:
+  type: sql
+  dsn_env: RECOTEM_RECIPE_DB_DSN
+  query: |
+    SELECT user_id, item_id, ts
+    FROM events
+    WHERE ts >= :since
+  query_parameters:
+    since: ${RECOTEM_RECIPE_SINCE}
+  connect_timeout_seconds: 10
+  statement_timeout_seconds: 300
+```
+
+| フィールド | 型 | デフォルト | 備考 |
+|------------|-----|-----------|------|
+| `dsn_env` | string | required | DSN を保持する環境変数の名前。`^RECOTEM_RECIPE_[A-Z0-9_]+$` に一致する必要があります。DSN 自体はレシピに書き込まれません。 |
+| `query` | string | required | 生の SQL。信頼されたコード — 環境変数展開されません。動的な値には `:name` を使用してください。 |
+| `query_parameters` | map | `{}` | SQLAlchemy の `text().bindparams(...)` 経由でバインドされます。`${RECOTEM_RECIPE_*}` 展開の対象です。 |
+| `connect_timeout_seconds` | int | `10` | 有効範囲 `[1, 60]`。 |
+| `statement_timeout_seconds` | int | `300` | 有効範囲 `[1, 1800]`。ダイアレクトごとの実装は [SQL ソース](./data-sources/sql#ステートメントタイムアウト) を参照してください。 |
+
+エクストラを 1 つインストール: `pip install "recotem[postgres]"`、`recotem[mysql]`、または `recotem[sqlite]`。詳細リファレンス: [SQL ソース](./data-sources/sql)。
+
+### `source.type: ga4`
+
+```yaml
+source:
+  type: ga4
+  property_id: "123456789"
+  user_dimension: userPseudoId
+  item_dimension: itemId
+  time_dimension: date
+  event_names: [purchase, view_item, add_to_cart]
+  lookback_days: 90               # start_date + end_date とは排他
+  max_rows: 1_000_000
+  weight_column: event_count
+  api_timeout_seconds: 60
+```
+
+| フィールド | 型 | デフォルト | 備考 |
+|------------|-----|-----------|------|
+| `property_id` | string | required | 数値のみ (`^\d+$`)。`G-XXXX` 形式の測定 ID ではありません。 |
+| `user_dimension` | string | required | `userId` または `userPseudoId`。 |
+| `item_dimension` | string | `itemId` | GA4 のアイテムスコープのディメンション。 |
+| `time_dimension` | string | `date` | `date` / `dateHour` / `dateHourMinute`。 |
+| `event_names` | list[string] | required | 1〜50 個のイベント名。各値は `^[A-Za-z_][A-Za-z0-9_]{0,39}$` に一致。 |
+| `lookback_days` | int | XOR | 1〜3650 日。前日で終わるローリングウィンドウ。 |
+| `start_date` / `end_date` | string (ISO) | XOR | いずれかを設定する場合は両方必須。 |
+| `max_rows` | int | required | 有効範囲 `[1, 50_000_000]`。 |
+| `weight_column` | string | `event_count` | ディメンションキーや `eventName` という値と衝突してはいけません。 |
+| `api_timeout_seconds` | int | `60` | 有効範囲 `[5, 600]`。 |
+
+エクストラのインストール: `pip install "recotem[ga4]"`。詳細リファレンス: [GA4 ソース](./data-sources/ga4)。
 
 ---
 


### PR DESCRIPTION
## Summary
Adds documentation for two new v2 recipe data sources — `sql` and `ga4` — in both English and Japanese, and wires them into the v2 docs sidebar.

## Changes Made
- New page `docs/data-sources/sql.md` (+ `ja/` mirror): connection strings, query/lookback config, ADC for Cloud SQL Connector, troubleshooting.
- New page `docs/data-sources/ga4.md` (+ `ja/` mirror): GA4 Data API source covering install extras, ADC setup, configuration, and quota notes.
- `.vitepress/config.ts`: register `SQL` and `GA4` entries under the v2 *Data sources* sidebar group (shared English/Japanese helper).
- `docs/index.md` / `ja/docs/index.md`: surface the new sources on the landing page.
- `docs/recipe-reference.md` / `ja/docs/recipe-reference.md`: extend the recipe reference with the new source types and their parameters.

## Testing
- `yarn docs:build` locally to confirm the new pages render and sidebar links resolve.
- Spot-check `/docs/data-sources/sql` and `/docs/data-sources/ga4` (and the `/ja/` variants) in `yarn docs:dev`.

## Breaking Changes
None — docs-only additions.

## Additional Notes
The English and Japanese pages are kept structurally in sync; please flag any drift in headings or code samples during review so both locales stay aligned.