### PR TITLE
docs: add SQL/GA4 data source extras and refine API/env-var docs

### DIFF
--- a/docs/deployment/docker.md
+++ b/docs/deployment/docker.md
@@ -73,7 +73,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 15s
+      start_period: 60s    # initial model load can take longer than 15s
     restart: unless-stopped
 
 volumes:

--- a/docs/deployment/kubernetes.md
+++ b/docs/deployment/kubernetes.md
@@ -22,7 +22,7 @@ kind: CronJob
 metadata:
   name: recotem-train
 spec:
-  schedule: "0 3 * * *"
+  schedule: "0 2 * * *"
   concurrencyPolicy: Forbid          # skip if a previous run is still active
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -127,7 +127,7 @@ spec:
             - name: RECOTEM_LOG_FORMAT
               value: "json"
             - name: RECOTEM_WATCH_INTERVAL
-              value: "30"
+              value: "10"
             - name: RECOTEM_DRAIN_SECONDS
               value: "30"
             - name: RECOTEM_SIGNING_KEYS

--- a/docs/environment-variables.md
+++ b/docs/environment-variables.md
@@ -78,7 +78,7 @@ These variables control the runtime environment, graceful shutdown, and log outp
 
 ## Operational
 
-These variables configure storage paths, locking, metadata field filtering, metrics, and BigQuery behaviour.
+These variables configure storage paths, locking, metadata field filtering, and metrics.
 
 | Variable | Default | Scope | Clamping | Description |
 |---|---|---|---|---|
@@ -86,7 +86,17 @@ These variables configure storage paths, locking, metadata field filtering, metr
 | `RECOTEM_LOCK_DIR` | (empty) | train | — | Override directory for per-recipe training lock files. Local `output.path` values always lock at `<output_path>.lock`. Remote `output.path` values (`s3://`, `gs://`, etc.) require a host-local lock file; if `RECOTEM_LOCK_DIR` is unset they fall back to `<tempdir>/recotem-locks/`. Note: `flock` is host-local — for cross-host single-writer guarantees use scheduler-level mutex (Kubernetes `concurrencyPolicy: Forbid`, etc.). |
 | `RECOTEM_METADATA_FIELD_DENY` | (empty) | serve | — | Comma-separated list of column names stripped from `/predict` responses after the item-metadata join. Matching is case-insensitive — `"Internal_ID"` in the metadata is stripped if `"internal_id"` is in the deny list. Use this to keep PII columns out of API responses. |
 | `RECOTEM_METRICS_ENABLED` | (unset) | serve | — | Truthy values: `1`, `true`, `yes`, `on`. Enables the Prometheus `/metrics` endpoint. Requires the `recotem[metrics]` extra (`pip install "recotem[metrics]"`). The endpoint is opt-in and off by default. |
+
+## Data source
+
+These variables tune behaviour of specific data sources. They are read only by `recotem train` and only when the corresponding source is used. See the [Data sources](./data-sources/) reference for full context.
+
+| Variable | Default | Scope | Clamping | Description |
+|---|---|---|---|---|
 | `RECOTEM_BQ_REQUIRE_STORAGE_API` | (unset) | train | — | Truthy values: `1`, `true`, `yes`, `on`. When set, the BigQuery source raises `DataSourceError` (exit 3) instead of silently falling back to the slower REST API when the BigQuery Storage Read API fails (e.g. missing `bigquery.readSessions.create` IAM permission). Use this to surface IAM gaps rather than accepting degraded throughput. |
+| `RECOTEM_MAX_SQL_ROWS` | `50_000_000` | train | [1_000, 500_000_000] | Hard cap on the number of rows returned by the SQL data source. Exceeding the cap raises `DataSourceError` (exit 3). Caps **row count**, not DataFrame resident memory — see [SQL source — memory bound caveat](./data-sources/sql#memory-bound-caveat). |
+| `RECOTEM_SQL_ALLOW_PRIVATE` | (unset) | train | — | Truthy values: `1`, `true`, `yes`, `on`. Opts the SQL source into accepting private/loopback DSN hosts (default deny, for SSRF). Covers every driver-routing form — netloc, `?host=`, `?hostaddr=`, `?service=`, `?unix_socket=`, absolute-path host, and network DSNs with no host info — all default-deny without this flag. Also disables the DNS-rebinding re-check before each probe/fetch — opting in means trusting the host end-to-end. |
+| `RECOTEM_GA4_MAX_PAGES` | `500` | train | [1, 10_000] | Hard ceiling on GA4 Data API pagination loops. Reached when a property is too large for the default; raise after confirming quota. |
 
 ## Recipe expansion
 

--- a/docs/recipe-reference.md
+++ b/docs/recipe-reference.md
@@ -92,7 +92,7 @@ source:
 
 | Field | Type | Default | Notes |
 |-------|------|---------|-------|
-| `dsn_env` | string | required | Name of an env var matching `^RECOTEM_RECIPE_[A-Z0-9_]+$` containing the DSN. The DSN itself is never written to the recipe. |
+| `dsn_env` | string | required | Name of an env var matching `^RECOTEM_RECIPE_[A-Z0-9_]+$` containing the DSN. The DSN itself is never written to the recipe. Not env-expanded — the field holds the variable *name*, not a value. |
 | `query` | string | required | Raw SQL. Trusted code — not env-expanded. Use `:name` for dynamic values. |
 | `query_parameters` | map | `{}` | Bound via SQLAlchemy `text().bindparams(...)`. Subject to `${RECOTEM_RECIPE_*}` expansion. |
 | `connect_timeout_seconds` | int | `10` | Valid range `[1, 60]`. |
@@ -319,7 +319,7 @@ Local paths are resolved to absolute. If `RECOTEM_ARTIFACT_ROOT` is set,
 
 Syntax: `${RECOTEM_RECIPE_VAR}`. Only variables matching the prefix `RECOTEM_RECIPE_*` are expanded. Matching is case-insensitive (the *upper-cased* name is checked against the prefix and blacklist). Additional values can be injected without exporting to the shell environment using `recotem train --env-var KEY=VALUE` (repeatable). The `KEY` must still start with `RECOTEM_RECIPE_` and pass the blacklist check. Example: `recotem train recipe.yaml --env-var RECOTEM_RECIPE_DATE=20260501`.
 
-Blacklisted (never expanded regardless of prefix): exact names `RECOTEM_SIGNING_KEYS` and `RECOTEM_API_KEYS`; names starting with `AWS_`, `GCP_`, `GOOGLE_`, or `AZURE_`; and any name containing the substrings `SECRET`, `PASSWORD`, `PASSWD`, `TOKEN`, `KEY`, `AUTH`, `BEARER`, `CRED`, or `PRIVATE` (all comparisons case-insensitive).
+Blacklisted (never expanded regardless of prefix): exact names `RECOTEM_SIGNING_KEYS` and `RECOTEM_API_KEYS`; names starting with `AWS_`, `GCP_`, `GOOGLE_`, `AZURE_`, `ALIYUN_`, `ALICLOUD_`, `OCI_`, `IBM_`, `DO_`, `HCLOUD_`, or `DIGITALOCEAN_` (cloud credential prefixes for AWS, GCP, Azure, Alibaba Cloud, Oracle Cloud, IBM Cloud, DigitalOcean, and Hetzner Cloud); and any name containing the substrings `SECRET`, `PASSWORD`, `PASSWD`, `TOKEN`, `KEY`, `AUTH`, `BEARER`, `CRED`, or `PRIVATE` (all comparisons case-insensitive).
 
 The `*KEY*` substring match is intentionally broad — any variable whose uppercased name contains the substring `KEY` (no underscore boundary) is rejected. This includes `RECOTEM_RECIPE_PARTITION_KEY`, `RECOTEM_RECIPE_APIKEY`, and `RECOTEM_RECIPE_KEYBOARD`. Use a name that does not contain `KEY` (e.g. `RECOTEM_RECIPE_PARTITION_COLUMN`).
 

--- a/docs/serving-api.md
+++ b/docs/serving-api.md
@@ -89,9 +89,9 @@ The `items` array is ordered by descending `score`. Each item always contains `i
 | Code | Condition | Response body `code` field |
 |------|-----------|---------------------------|
 | 200 | Success | — |
-| 401 | Missing or invalid `X-API-Key` | — |
+| 401 | Missing or invalid `X-API-Key` | `missing_api_key` or `invalid_api_key` |
 | 404 | `user_id` was not present in training data | `user_not_found` |
-| 422 | Request body failed schema validation (missing `user_id`, `cutoff` out of range) | — |
+| 422 | Request body failed schema validation (missing `user_id`, `cutoff` out of range) | — (FastAPI default validation envelope) |
 | 503 | Recipe is not loaded or unhealthy | `recipe_unavailable` |
 
 **curl example:**
@@ -136,7 +136,7 @@ Overall health status. Safe for Kubernetes readiness and liveness probes.
 | Code | Condition |
 |------|-----------|
 | 200 | All registered recipes are loaded and error-free. |
-| 503 | One or more recipes are unloaded or carry a `last_load_error`. |
+| 503 | One or more recipes are unloaded or carry a load error. |
 
 ::: tip
 Use HTTP status code only for probe logic. A `status: degraded` response returns 503, which causes Kubernetes readiness probes to remove the pod from the Service endpoints. This is intentional — a pod where every predict call returns 503 should not receive traffic.
@@ -168,21 +168,17 @@ Per-recipe detail is behind authentication because it includes artifact key iden
       "loaded": true,
       "trained_at": "2026-05-07T01:23:45Z",
       "best_class": "IALSRecommender",
-      "kid": "prod-2026-q2",
-      "last_load_error": null
+      "kid": "prod-2026-q2"
     },
     "product_recs": {
       "loaded": false,
-      "trained_at": null,
-      "best_class": null,
-      "kid": null,
-      "last_load_error": "signature mismatch"
+      "error": "signature mismatch"
     }
   }
 }
 ```
 
-Every recipe found in the recipes directory appears here, regardless of whether its artifact loaded — startup-failed recipes appear as stubs with `loaded: false` and a non-null `last_load_error`.
+Every recipe found in the recipes directory appears here, regardless of whether its artifact loaded — startup-failed recipes appear as stubs with `loaded: false` and an `error` field. Optional fields (`trained_at`, `best_class`, `kid`, `error`) are present only when their underlying value is set; absent fields imply the corresponding value is unset.
 
 **Status codes:** Same as `GET /health` — 503 when any recipe is unloaded or carries a load error.
 

--- a/guide/installation.md
+++ b/guide/installation.md
@@ -28,6 +28,10 @@ The core package ships with CSV and Parquet data sources. Install extras for add
 | Extra | Command | What it adds |
 |---|---|---|
 | BigQuery data source | `pip install "recotem[bigquery]"` | Read interaction data from Google BigQuery |
+| PostgreSQL data source | `pip install "recotem[postgres]"` | Read interaction data from PostgreSQL via psycopg |
+| MySQL / MariaDB data source | `pip install "recotem[mysql]"` | Read interaction data from MySQL or MariaDB via PyMySQL |
+| SQLite data source | `pip install "recotem[sqlite]"` | Read interaction data from SQLite (uses stdlib `sqlite3`) |
+| Google Analytics 4 data source | `pip install "recotem[ga4]"` | Read interaction events from GA4 via the Data API |
 | Amazon S3 | `pip install "recotem[s3]"` | Read/write artifacts and data from S3 |
 | Google Cloud Storage | `pip install "recotem[gcs]"` | Read/write artifacts and data from GCS |
 | Azure Blob Storage | `pip install "recotem[azure]"` | Read/write artifacts and data from Azure |

--- a/ja/docs/deployment/docker.md
+++ b/ja/docs/deployment/docker.md
@@ -73,7 +73,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 15s
+      start_period: 60s    # 初回のモデルロードは 15 秒以上かかる場合がある
     restart: unless-stopped
 
 volumes:

--- a/ja/docs/deployment/kubernetes.md
+++ b/ja/docs/deployment/kubernetes.md
@@ -22,7 +22,7 @@ kind: CronJob
 metadata:
   name: recotem-train
 spec:
-  schedule: "0 3 * * *"
+  schedule: "0 2 * * *"
   concurrencyPolicy: Forbid          # 前回の実行がまだ進行中の場合はスキップ
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -127,7 +127,7 @@ spec:
             - name: RECOTEM_LOG_FORMAT
               value: "json"
             - name: RECOTEM_WATCH_INTERVAL
-              value: "30"
+              value: "10"
             - name: RECOTEM_DRAIN_SECONDS
               value: "30"
             - name: RECOTEM_SIGNING_KEYS

--- a/ja/docs/environment-variables.md
+++ b/ja/docs/environment-variables.md
@@ -78,7 +78,7 @@ title: 環境変数
 
 ## 運用
 
-これらの変数はストレージパス、ロック、メタデータフィールドフィルタリング、メトリクス、BigQuery の動作を設定します。
+これらの変数はストレージパス、ロック、メタデータフィールドフィルタリング、メトリクスを設定します。
 
 | 変数 | デフォルト | スコープ | クランプ | 説明 |
 |---|---|---|---|---|
@@ -86,7 +86,17 @@ title: 環境変数
 | `RECOTEM_LOCK_DIR` | (空) | train | — | レシピごとの学習ロックファイルのディレクトリを上書きする。ローカルの `output.path` 値は常に `<output_path>.lock` でロックされる。リモートの `output.path` 値 (`s3://`、`gs://` など) はホストローカルのロックファイルを必要とする。`RECOTEM_LOCK_DIR` が未設定の場合は `<tempdir>/recotem-locks/` にフォールバックする。注意: `flock` はホストローカル — ホスト間のシングルライター保証にはスケジューラーレベルのミューテックスを使用すること (Kubernetes の `concurrencyPolicy: Forbid` など)。 |
 | `RECOTEM_METADATA_FIELD_DENY` | (空) | serve | — | アイテムメタデータ結合後に `/predict` レスポンスから除外する列名のカンマ区切りリスト。マッチングは大文字小文字を区別しない — メタデータの `"Internal_ID"` は拒否リストに `"internal_id"` があればストリップされる。PII 列を API レスポンスから除外するために使用する。 |
 | `RECOTEM_METRICS_ENABLED` | (未設定) | serve | — | 真値: `1`、`true`、`yes`、`on`。Prometheus `/metrics` エンドポイントを有効化する。`recotem[metrics]` エクストラが必要 (`pip install "recotem[metrics]"`)。エンドポイントはオプトインでデフォルトでは無効。 |
+
+## データソース
+
+これらの変数は特定のデータソースの動作を調整します。`recotem train` のみが、対応するソースが使用されたときのみ読み取ります。詳細は [データソース](./data-sources/) リファレンスを参照してください。
+
+| 変数 | デフォルト | スコープ | クランプ | 説明 |
+|---|---|---|---|---|
 | `RECOTEM_BQ_REQUIRE_STORAGE_API` | (未設定) | train | — | 真値: `1`、`true`、`yes`、`on`。設定すると、BigQuery Storage Read API が失敗した場合 (例: `bigquery.readSessions.create` IAM 権限の欠落) に BigQuery ソースがより遅い REST API にサイレントフォールバックするのではなく、`DataSourceError` (終了コード 3) を発生させる。スループット低下を受け入れるのではなく IAM のギャップを表面化させるために使用する。 |
+| `RECOTEM_MAX_SQL_ROWS` | `50_000_000` | train | [1_000, 500_000_000] | SQL データソースが返す行数のハードキャップ。上限を超えると `DataSourceError` (終了コード 3) を発生させる。**行数**をキャップするのであって、DataFrame の常駐メモリではない — [SQL ソース — メモリバウンドの注意点](./data-sources/sql#memory-bound-caveat) を参照。 |
+| `RECOTEM_SQL_ALLOW_PRIVATE` | (未設定) | train | — | 真値: `1`、`true`、`yes`、`on`。SQL ソースがプライベート / ループバックの DSN ホストを受け入れるオプトイン (デフォルトは SSRF 対策のため拒否)。あらゆるドライバルーティング形式 (netloc、`?host=`、`?hostaddr=`、`?service=`、`?unix_socket=`、絶対パスホスト、ホスト情報のないネットワーク DSN) をカバー — このフラグなしでは全てデフォルトで拒否される。各プローブ / フェッチ前の DNS リバインディング再チェックも無効化される — オプトインはホストをエンドツーエンドで信頼することを意味する。 |
+| `RECOTEM_GA4_MAX_PAGES` | `500` | train | [1, 10_000] | GA4 Data API ページネーションループのハード上限。デフォルト上限ではプロパティが大きすぎる場合に到達する。クォータを確認してから引き上げること。 |
 
 ## レシピ展開
 

--- a/ja/docs/recipe-reference.md
+++ b/ja/docs/recipe-reference.md
@@ -92,7 +92,7 @@ source:
 
 | フィールド | 型 | デフォルト | 備考 |
 |------------|-----|-----------|------|
-| `dsn_env` | string | required | DSN を保持する環境変数の名前。`^RECOTEM_RECIPE_[A-Z0-9_]+$` に一致する必要があります。DSN 自体はレシピに書き込まれません。 |
+| `dsn_env` | string | required | DSN を保持する環境変数の名前。`^RECOTEM_RECIPE_[A-Z0-9_]+$` に一致する必要があります。DSN 自体はレシピに書き込まれません。環境変数展開の対象外 — このフィールドは変数の*名前*を保持するものであり、値ではありません。 |
 | `query` | string | required | 生の SQL。信頼されたコード — 環境変数展開されません。動的な値には `:name` を使用してください。 |
 | `query_parameters` | map | `{}` | SQLAlchemy の `text().bindparams(...)` 経由でバインドされます。`${RECOTEM_RECIPE_*}` 展開の対象です。 |
 | `connect_timeout_seconds` | int | `10` | 有効範囲 `[1, 60]`。 |
@@ -300,7 +300,7 @@ output:
 
 構文: `${RECOTEM_RECIPE_VAR}`。プレフィックス `RECOTEM_RECIPE_*` に一致する変数のみ展開されます。マッチングは大文字小文字を区別しません (大文字に変換された名前がプレフィックスとブラックリストに対してチェックされます)。`recotem train --env-var KEY=VALUE` (繰り返し指定可能) を使用して、シェル環境にエクスポートせずに追加の値を注入できます。`KEY` は `RECOTEM_RECIPE_` で始まり、ブラックリストチェックをパスする必要があります。例: `recotem train recipe.yaml --env-var RECOTEM_RECIPE_DATE=20260501`。
 
-ブラックリスト (プレフィックスに関わらず展開されない): 正確な名前 `RECOTEM_SIGNING_KEYS` および `RECOTEM_API_KEYS`。`AWS_`、`GCP_`、`GOOGLE_`、`AZURE_` で始まる名前。`SECRET`、`PASSWORD`、`PASSWD`、`TOKEN`、`KEY`、`AUTH`、`BEARER`、`CRED`、`PRIVATE` という部分文字列を含む名前 (全て大文字小文字を区別しない比較)。
+ブラックリスト (プレフィックスに関わらず展開されない): 正確な名前 `RECOTEM_SIGNING_KEYS` および `RECOTEM_API_KEYS`。`AWS_`、`GCP_`、`GOOGLE_`、`AZURE_`、`ALIYUN_`、`ALICLOUD_`、`OCI_`、`IBM_`、`DO_`、`HCLOUD_`、`DIGITALOCEAN_` で始まる名前 (AWS、GCP、Azure、Alibaba Cloud、Oracle Cloud、IBM Cloud、DigitalOcean、Hetzner Cloud のクラウド認証情報プレフィックス)。`SECRET`、`PASSWORD`、`PASSWD`、`TOKEN`、`KEY`、`AUTH`、`BEARER`、`CRED`、`PRIVATE` という部分文字列を含む名前 (全て大文字小文字を区別しない比較)。
 
 `*KEY*` の部分文字列マッチは意図的に広く取られています — 大文字に変換した名前に部分文字列 `KEY` (アンダースコアの境界なし) が含まれる変数は拒否されます。これには `RECOTEM_RECIPE_PARTITION_KEY`、`RECOTEM_RECIPE_APIKEY`、`RECOTEM_RECIPE_KEYBOARD` が含まれます。`KEY` を含まない名前を使用してください (例: `RECOTEM_RECIPE_PARTITION_COLUMN`)。
 

--- a/ja/docs/serving-api.md
+++ b/ja/docs/serving-api.md
@@ -89,9 +89,9 @@ API キー認証は `X-API-Key` リクエストヘッダーを使用します。
 | コード | 条件 | レスポンスボディの `code` フィールド |
 |--------|------|-------------------------------------|
 | 200 | 成功 | — |
-| 401 | `X-API-Key` が欠落または不正 | — |
+| 401 | `X-API-Key` が欠落または不正 | `missing_api_key` または `invalid_api_key` |
 | 404 | `user_id` が学習データに存在しない | `user_not_found` |
-| 422 | リクエストボディのスキーマバリデーション失敗 (`user_id` の欠落、`cutoff` が範囲外) | — |
+| 422 | リクエストボディのスキーマバリデーション失敗 (`user_id` の欠落、`cutoff` が範囲外) | — (FastAPI デフォルトのバリデーション形式) |
 | 503 | レシピがロードされていないか異常 | `recipe_unavailable` |
 
 **curl の例:**
@@ -136,7 +136,7 @@ curl -s -X POST http://localhost:8080/predict/news_articles \
 | コード | 条件 |
 |--------|------|
 | 200 | 全登録レシピがロード済みかつエラーなし。 |
-| 503 | 1 件以上のレシピが未ロードまたは `last_load_error` を持つ。 |
+| 503 | 1 件以上のレシピが未ロードまたはロードエラーを持つ。 |
 
 ::: tip
 プローブのロジックには HTTP ステータスコードのみを使用してください。`status: degraded` のレスポンスは 503 を返し、Kubernetes の readiness プローブがその Pod を Service エンドポイントから除外します。これは意図的な動作です — 全ての predict 呼び出しが 503 を返す Pod にはトラフィックを送るべきではありません。
@@ -168,21 +168,17 @@ curl -s http://localhost:8080/health | jq .
       "loaded": true,
       "trained_at": "2026-05-07T01:23:45Z",
       "best_class": "IALSRecommender",
-      "kid": "prod-2026-q2",
-      "last_load_error": null
+      "kid": "prod-2026-q2"
     },
     "product_recs": {
       "loaded": false,
-      "trained_at": null,
-      "best_class": null,
-      "kid": null,
-      "last_load_error": "signature mismatch"
+      "error": "signature mismatch"
     }
   }
 }
 ```
 
-レシピディレクトリで見つかった全レシピは、アーティファクトがロードされたかどうかに関わらずここに表示されます。起動時に失敗したレシピは `loaded: false` と null でない `last_load_error` を持つスタブとして表示されます。
+レシピディレクトリで見つかった全レシピは、アーティファクトがロードされたかどうかに関わらずここに表示されます。起動時に失敗したレシピは `loaded: false` と `error` フィールドを持つスタブとして表示されます。オプションフィールド (`trained_at`、`best_class`、`kid`、`error`) は対応する値が設定されている場合のみ存在します。フィールドが存在しない場合、対応する値は未設定であることを意味します。
 
 **ステータスコード:** `GET /health` と同じ — いずれかのレシピが未ロードまたはロードエラーを持つ場合は 503。
 

--- a/ja/guide/installation.md
+++ b/ja/guide/installation.md
@@ -28,6 +28,10 @@ recotem --help
 | エクストラ | コマンド | 追加される機能 |
 |---|---|---|
 | BigQuery データソース | `pip install "recotem[bigquery]"` | Google BigQuery からインタラクションデータを読み込む |
+| PostgreSQL データソース | `pip install "recotem[postgres]"` | psycopg 経由で PostgreSQL からインタラクションデータを読み込む |
+| MySQL / MariaDB データソース | `pip install "recotem[mysql]"` | PyMySQL 経由で MySQL または MariaDB からインタラクションデータを読み込む |
+| SQLite データソース | `pip install "recotem[sqlite]"` | SQLite からインタラクションデータを読み込む (標準ライブラリの `sqlite3` を使用) |
+| Google Analytics 4 データソース | `pip install "recotem[ga4]"` | Data API 経由で GA4 からインタラクションイベントを読み込む |
 | Amazon S3 | `pip install "recotem[s3]"` | S3 からアーティファクトとデータを読み書きする |
 | Google Cloud Storage | `pip install "recotem[gcs]"` | GCS からアーティファクトとデータを読み書きする |
 | Azure Blob Storage | `pip install "recotem[azure]"` | Azure からアーティファクトとデータを読み書きする |


### PR DESCRIPTION
## Summary
Documentation updates that finish out the SQL/GA4 data source story and refine a few API and operational details. Mirrored in both English and Japanese.

## Changes Made

**Installation**
- Add install-extra rows for `recotem[postgres]`, `recotem[mysql]`, `recotem[sqlite]`, and `recotem[ga4]`.

**Environment variables**
- Split a new **Data source** section out of **Operational** (BigQuery toggle moved here for consistency).
- Document `RECOTEM_MAX_SQL_ROWS` (default 50M, clamped [1k, 500M]) — caps row count, not DataFrame memory.
- Document `RECOTEM_SQL_ALLOW_PRIVATE` — opt-in for private/loopback DSN hosts; also disables DNS-rebinding re-check.
- Document `RECOTEM_GA4_MAX_PAGES` (default 500, clamped [1, 10k]).

**Recipe reference**
- Clarify `dsn_env` holds the variable *name*, not the value (not env-expanded).
- Expand env-expansion blacklist to cover `ALIYUN_`, `ALICLOUD_`, `OCI_`, `IBM_`, `DO_`, `HCLOUD_`, `DIGITALOCEAN_` cloud credential prefixes.

**Serving API (`/predict`, `/recipes`)**
- Document `missing_api_key` / `invalid_api_key` codes for 401.
- Note 422 uses the FastAPI default validation envelope.
- Replace `last_load_error` (nullable) with optional `error` field; document that `trained_at`, `best_class`, `kid`, `error` are present only when set.

**Deployment**
- Docker Compose: bump `start_period` from 15s to 60s (initial model load can take longer than 15s).
- Kubernetes: shift `recotem-train` CronJob to `0 2 * * *`, drop `RECOTEM_WATCH_INTERVAL` example from 30 to 10.

## Testing
- `yarn docs:build` to confirm VitePress compiles both locales without broken links.

## Breaking Changes
None — documentation only.

## Additional Notes
The `last_load_error` → `error` change in the `/recipes` example matches the new optional-field shape; reviewers should confirm this aligns with the implementation in the serving codebase before merge.